### PR TITLE
Add Jetty API server and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This project combines the following technologies:
 
 into a system that accepts a workflow definition, deploys it on Kubernetes, starts executing the tasks while it uses the journaling capabilities of Restate to keep track of everything.
 
+An embedded Jetty server exposes an HTTP endpoint on port `8080`. Posting a workflow definition to `/workflows` creates a `Workflow` custom resource which triggers execution via the operator.
+
 ## Building
 
 This is a standard Maven project. To build it, run:

--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,9 @@
   <artifactId>durable-workflow-operator</artifactId>
   <version>0.1.0-SNAPSHOT</version>
   <properties>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <dependencies>
     <!-- Java Operator SDK -->
@@ -39,5 +40,43 @@
       <artifactId>jackson-databind</artifactId>
       <version>2.17.1</version>
     </dependency>
+    <!-- Jetty server and servlet API -->
+    <dependency>
+      <groupId>org.eclipse.jetty.ee10</groupId>
+      <artifactId>jetty-ee10-servlet</artifactId>
+      <version>12.0.9</version>
+    </dependency>
+    <!-- Testing libraries -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.13.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.13.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.18.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.1.2</version>
+        <configuration>
+          <useModulePath>false</useModulePath>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/src/main/java/com/example/workflow/operator/Main.java
+++ b/src/main/java/com/example/workflow/operator/Main.java
@@ -3,6 +3,7 @@ package com.example.workflow.operator;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.javaoperatorsdk.operator.Operator;
+import com.example.workflow.operator.api.WorkflowApiServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,7 +15,12 @@ public class Main {
         try (DefaultKubernetesClient client = new DefaultKubernetesClient(Config.autoConfigure(null))) {
             Operator operator = new Operator(client);
             operator.register(new WorkflowReconciler());
+            WorkflowApiServer apiServer = new WorkflowApiServer(client);
+            apiServer.start();
             operator.start();
+            apiServer.stop();
+        } catch (Exception e) {
+            log.error("Operator failed", e);
         }
     }
 }

--- a/src/main/java/com/example/workflow/operator/Workflow.java
+++ b/src/main/java/com/example/workflow/operator/Workflow.java
@@ -1,7 +1,19 @@
 package com.example.workflow.operator;
 
 import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
+import io.fabric8.kubernetes.model.annotation.Kind;
+import io.fabric8.kubernetes.model.annotation.Plural;
+import io.fabric8.kubernetes.model.annotation.Singular;
+import io.fabric8.kubernetes.model.annotation.ShortNames;
 
+@Group("example.com")
+@Version("v1alpha1")
+@Kind("Workflow")
+@Plural("workflows")
+@Singular("workflow")
+@ShortNames("wf")
 public class Workflow extends CustomResource<WorkflowSpec, WorkflowStatus> {
     // no additional fields
 }

--- a/src/main/java/com/example/workflow/operator/api/WorkflowApiServer.java
+++ b/src/main/java/com/example/workflow/operator/api/WorkflowApiServer.java
@@ -1,0 +1,26 @@
+package com.example.workflow.operator.api;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.servlet.ServletHolder;
+import org.eclipse.jetty.server.Server;
+
+public class WorkflowApiServer {
+    private final Server server;
+
+    public WorkflowApiServer(KubernetesClient client) {
+        this.server = new Server(8080);
+        ServletContextHandler context = new ServletContextHandler();
+        context.setContextPath("/");
+        context.addServlet(new ServletHolder(new WorkflowServlet(client)), "/workflows");
+        server.setHandler(context);
+    }
+
+    public void start() throws Exception {
+        server.start();
+    }
+
+    public void stop() throws Exception {
+        server.stop();
+    }
+}

--- a/src/main/java/com/example/workflow/operator/api/WorkflowServlet.java
+++ b/src/main/java/com/example/workflow/operator/api/WorkflowServlet.java
@@ -1,0 +1,44 @@
+package com.example.workflow.operator.api;
+
+import com.example.workflow.operator.Workflow;
+import com.example.workflow.operator.WorkflowSpec;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+public class WorkflowServlet extends HttpServlet {
+    private static final Logger log = LoggerFactory.getLogger(WorkflowServlet.class);
+    private final KubernetesClient client;
+
+    public WorkflowServlet(KubernetesClient client) {
+        this.client = client;
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        String definition = new String(req.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        Workflow wf = new Workflow();
+        ObjectMeta meta = new ObjectMeta();
+        meta.setName("wf-" + UUID.randomUUID());
+        wf.setMetadata(meta);
+        WorkflowSpec spec = new WorkflowSpec();
+        spec.setDefinition(definition);
+        wf.setSpec(spec);
+        try {
+            client.resources(Workflow.class).inNamespace("default").resource(wf).create();
+            resp.setStatus(HttpServletResponse.SC_CREATED);
+            resp.getWriter().write(wf.getMetadata().getName());
+        } catch (Exception e) {
+            log.error("Failed to create Workflow CR", e);
+            resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/example/workflow/operator/WorkflowRunnerTest.java
+++ b/src/test/java/com/example/workflow/operator/WorkflowRunnerTest.java
@@ -1,0 +1,27 @@
+package com.example.workflow.operator;
+
+import dev.restate.sdk.endpoint.Endpoint;
+import dev.restate.sdk.http.vertx.RestateHttpServer;
+import io.serverlessworkflow.api.Workflow;
+import io.serverlessworkflow.api.deserializers.WorkflowParser;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+public class WorkflowRunnerTest {
+    @Test
+    void runInvokesParser() {
+        Workflow workflow = new Workflow();
+        try (MockedStatic<WorkflowParser> parser = Mockito.mockStatic(WorkflowParser.class);
+             MockedStatic<RestateHttpServer> server = Mockito.mockStatic(RestateHttpServer.class)) {
+            parser.when(() -> WorkflowParser.parse("def")).thenReturn(workflow);
+            server.when(() -> RestateHttpServer.listen(Mockito.any(Endpoint.class))).thenReturn(null);
+
+            WorkflowRunner runner = new WorkflowRunner();
+            runner.run("def");
+
+            parser.verify(() -> WorkflowParser.parse("def"));
+            server.verify(() -> RestateHttpServer.listen(Mockito.any(Endpoint.class)));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- use Java 21 and add Jetty 12 + JUnit/Mockito deps
- provide Jetty server exposing `/workflows` servlet
- start API server from `Main`
- add unit test for `WorkflowRunner`
- document HTTP API

## Testing
- `mvn -q test` *(fails: Could not resolve plugin due to network)*

------
https://chatgpt.com/codex/tasks/task_e_684b7354857c83249037c2ab79c63289