### PR TITLE
Add local end-to-end test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,12 @@
       <version>5.18.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-server-mock</artifactId>
+      <version>7.3.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/example/workflow/operator/api/WorkflowApiServer.java
+++ b/src/main/java/com/example/workflow/operator/api/WorkflowApiServer.java
@@ -7,9 +7,15 @@ import org.eclipse.jetty.server.Server;
 
 public class WorkflowApiServer {
     private final Server server;
+    private final int port;
 
     public WorkflowApiServer(KubernetesClient client) {
-        this.server = new Server(8080);
+        this(client, 8080);
+    }
+
+    public WorkflowApiServer(KubernetesClient client, int port) {
+        this.port = port;
+        this.server = new Server(port);
         ServletContextHandler context = new ServletContextHandler();
         context.setContextPath("/");
         context.addServlet(new ServletHolder(new WorkflowServlet(client)), "/workflows");
@@ -22,5 +28,12 @@ public class WorkflowApiServer {
 
     public void stop() throws Exception {
         server.stop();
+    }
+
+    public int getPort() {
+        if (port == 0) {
+            return server.getURI().getPort();
+        }
+        return port;
     }
 }

--- a/src/test/java/com/example/workflow/operator/WorkflowEndToEndTest.java
+++ b/src/test/java/com/example/workflow/operator/WorkflowEndToEndTest.java
@@ -1,0 +1,61 @@
+package com.example.workflow.operator;
+
+import com.example.workflow.operator.api.WorkflowApiServer;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import io.javaoperatorsdk.operator.Operator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class WorkflowEndToEndTest {
+
+    @RegisterExtension
+    static KubernetesServer server = new KubernetesServer(true, true);
+
+    @Test
+    void workflowIsDeployed() throws Exception {
+        KubernetesClient client = server.getClient();
+
+        Operator operator = new Operator(client);
+        operator.register(new WorkflowResourceReconciler());
+        Thread operatorThread = new Thread(operator::start);
+        operatorThread.start();
+
+        WorkflowApiServer apiServer = new WorkflowApiServer(client, 0);
+        apiServer.start();
+        int port = apiServer.getPort();
+
+        String json = "{\"id\":\"test\",\"version\":\"1.0\",\"states\":[]}";
+        HttpClient http = HttpClient.newHttpClient();
+        HttpRequest req = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:" + port + "/workflows"))
+                .POST(HttpRequest.BodyPublishers.ofString(json))
+                .build();
+        HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString());
+        assertEquals(201, resp.statusCode());
+        String name = resp.body();
+
+        Workflow wf = null;
+        for (int i = 0; i < 20; i++) {
+            wf = client.resources(Workflow.class).inNamespace("default").withName(name).get();
+            if (wf != null && wf.getStatus() != null) {
+                break;
+            }
+            Thread.sleep(100);
+        }
+        assertNotNull(wf);
+        assertNotNull(wf.getStatus());
+        assertEquals("Deployed", wf.getStatus().getPhase());
+
+        operator.stop();
+        operatorThread.join(1000);
+        apiServer.stop();
+    }
+}


### PR DESCRIPTION
## Summary
- allow choosing the WorkflowApiServer port
- include fabric8 Kubernetes mock server for testing
- add a new end-to-end JUnit test to exercise operator, API server and reconciler

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684b972a45908324a75a8957e168b9a2