### PR TITLE
Add new tasks and YAML workflow test

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Workflows can currently execute the following simple tasks:
 - `set` &mdash; update workflow data with key/value pairs
 - `log` &mdash; write a message to the operator log
 - `fetch` &mdash; perform an HTTP GET and store the response
+- `post` &mdash; perform an HTTP POST and store the response
+- `unset` &mdash; remove variables from workflow data
 
 ## Building
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,18 @@
       <artifactId>jackson-databind</artifactId>
       <version>2.17.1</version>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+      <version>2.17.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <version>2.17.1</version>
+      <scope>test</scope>
+    </dependency>
     <!-- Jetty server and servlet API -->
     <dependency>
       <groupId>org.eclipse.jetty.ee10</groupId>

--- a/src/main/java/com/example/workflow/operator/RestateWorkflowRunner.java
+++ b/src/main/java/com/example/workflow/operator/RestateWorkflowRunner.java
@@ -78,8 +78,25 @@ public class RestateWorkflowRunner {
                             log.error("HTTP fetch failed", e);
                         }
                     }
+                    if (state.getPostUrl() != null && state.getPostVar() != null) {
+                        HttpClient http = HttpClient.newHttpClient();
+                        try {
+                            HttpRequest request = HttpRequest.newBuilder(URI.create(state.getPostUrl()))
+                                    .POST(HttpRequest.BodyPublishers.ofString(state.getPostBody() == null ? "" : state.getPostBody()))
+                                    .build();
+                            HttpResponse<String> resp = http.send(request, HttpResponse.BodyHandlers.ofString());
+                            data.put(state.getPostVar(), resp.body());
+                        } catch (Exception e) {
+                            log.error("HTTP post failed", e);
+                        }
+                    }
                     if (state.getSet() != null) {
                         data.putAll(state.getSet());
+                    }
+                    if (state.getUnset() != null) {
+                        for (String key : state.getUnset()) {
+                            data.remove(key);
+                        }
                     }
                 });
             }

--- a/src/main/java/com/example/workflow/operator/model/ServerlessState.java
+++ b/src/main/java/com/example/workflow/operator/model/ServerlessState.java
@@ -1,5 +1,7 @@
 package com.example.workflow.operator.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Duration;
 import java.util.Map;
 
@@ -13,8 +15,17 @@ public class ServerlessState {
     private String fetchUrl;
     // name of variable to store fetched result
     private String fetchVar;
+    // URL to invoke via HTTP POST
+    private String postUrl;
+    // POST request body
+    private String postBody;
+    // name of variable to store POST response
+    private String postVar;
+    // variables to remove from the workflow data
+    private java.util.List<String> unset;
 
-    public ServerlessState(String name) {
+    @JsonCreator
+    public ServerlessState(@JsonProperty("name") String name) {
         this.name = name;
     }
 
@@ -62,6 +73,38 @@ public class ServerlessState {
         this.fetchVar = fetchVar;
     }
 
+    public String getPostUrl() {
+        return postUrl;
+    }
+
+    public void setPostUrl(String postUrl) {
+        this.postUrl = postUrl;
+    }
+
+    public String getPostBody() {
+        return postBody;
+    }
+
+    public void setPostBody(String postBody) {
+        this.postBody = postBody;
+    }
+
+    public String getPostVar() {
+        return postVar;
+    }
+
+    public void setPostVar(String postVar) {
+        this.postVar = postVar;
+    }
+
+    public java.util.List<String> getUnset() {
+        return unset == null ? null : new java.util.ArrayList<>(unset);
+    }
+
+    public void setUnset(java.util.List<String> unset) {
+        this.unset = unset == null ? null : new java.util.ArrayList<>(unset);
+    }
+
     ServerlessState copy() {
         ServerlessState copy = new ServerlessState(name);
         copy.wait = wait;
@@ -69,6 +112,10 @@ public class ServerlessState {
         copy.log = log;
         copy.fetchUrl = fetchUrl;
         copy.fetchVar = fetchVar;
+        copy.postUrl = postUrl;
+        copy.postBody = postBody;
+        copy.postVar = postVar;
+        copy.unset = getUnset();
         return copy;
     }
 }

--- a/src/test/java/com/example/workflow/operator/WorkflowDslYamlTest.java
+++ b/src/test/java/com/example/workflow/operator/WorkflowDslYamlTest.java
@@ -1,0 +1,62 @@
+package com.example.workflow.operator;
+
+import com.example.workflow.operator.model.ServerlessWorkflow;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import dev.restate.common.function.ThrowingRunnable;
+import dev.restate.sdk.WorkflowContext;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import com.sun.net.httpserver.HttpServer;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class WorkflowDslYamlTest {
+    @Test
+    void runsYamlWorkflow() throws Exception {
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/get", exch -> {
+            byte[] data = "get".getBytes(StandardCharsets.UTF_8);
+            exch.sendResponseHeaders(200, data.length);
+            exch.getResponseBody().write(data);
+            exch.close();
+        });
+        server.createContext("/post", exch -> {
+            byte[] body = exch.getRequestBody().readAllBytes();
+            exch.sendResponseHeaders(200, body.length);
+            exch.getResponseBody().write(body);
+            exch.close();
+        });
+        server.start();
+        int port = server.getAddress().getPort();
+
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        mapper.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
+        ServerlessWorkflow wf;
+        try (InputStream in = WorkflowDslYamlTest.class.getResourceAsStream("/workflows/sample.yaml")) {
+            String yaml = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+            yaml = yaml.replace("FETCH_URL", "http://localhost:" + port + "/get");
+            yaml = yaml.replace("POST_URL", "http://localhost:" + port + "/post");
+            wf = mapper.readValue(yaml, ServerlessWorkflow.class);
+        }
+
+        RestateWorkflowRunner.ServerlessWorkflowService service = new RestateWorkflowRunner.ServerlessWorkflowService(wf);
+        WorkflowContext ctx = Mockito.mock(WorkflowContext.class);
+        Mockito.doAnswer(invocation -> {
+            ThrowingRunnable r = invocation.getArgument(1);
+            r.run();
+            return null;
+        }).when(ctx).run(Mockito.anyString(), Mockito.any(ThrowingRunnable.class));
+
+        String result = service.run(ctx);
+        assertEquals("completed", result);
+        assertNull(service.getData().get("foo"));
+        assertEquals("get", service.getData().get("fetched"));
+        assertEquals("hi", service.getData().get("posted"));
+
+        server.stop(0);
+    }
+}

--- a/src/test/resources/workflows/sample.yaml
+++ b/src/test/resources/workflows/sample.yaml
@@ -1,0 +1,18 @@
+id: dsl-test
+version: "1.0"
+states:
+  - name: wait
+    wait: PT0.1S
+  - name: set
+    set:
+      foo: bar
+  - name: fetch
+    fetchUrl: FETCH_URL
+    fetchVar: fetched
+  - name: post
+    postUrl: POST_URL
+    postBody: hi
+    postVar: posted
+  - name: cleanup
+    unset:
+      - foo


### PR DESCRIPTION
## Summary
- support `post` and `unset` tasks in `ServerlessState`
- implement handling of new tasks in `RestateWorkflowRunner`
- document new tasks in README
- parse YAML workflows in tests
- add integration test that loads a YAML workflow with several tasks

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_684baa4b29ac83249992d26cac4ded5f