### PR TITLE
Add YAML workflow parsing

### DIFF
--- a/src/main/java/com/example/workflow/operator/model/WorkflowParser.java
+++ b/src/main/java/com/example/workflow/operator/model/WorkflowParser.java
@@ -1,0 +1,25 @@
+package com.example.workflow.operator.model;
+
+import io.serverlessworkflow.api.WorkflowFormat;
+import io.serverlessworkflow.api.WorkflowReader;
+import io.serverlessworkflow.api.types.Workflow;
+import java.io.IOException;
+
+/** Utility class to parse workflow definitions in YAML format. */
+public final class WorkflowParser {
+    private WorkflowParser() {}
+
+    /**
+     * Parse the given YAML string into the internal {@link ServerlessWorkflow} model.
+     * Only the workflow id (mapped from document name) and version are extracted.
+     */
+    public static ServerlessWorkflow parseYaml(String yaml) throws IOException {
+        Workflow wf = WorkflowReader.readWorkflowFromString(yaml, WorkflowFormat.YAML);
+        ServerlessWorkflow result = new ServerlessWorkflow();
+        if (wf.getDocument() != null) {
+            result.setId(wf.getDocument().getName());
+            result.setVersion(wf.getDocument().getVersion());
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
## Summary
- parse YAML workflows via `WorkflowParser`
- allow `WorkflowServlet` to accept YAML payloads
- test creating Workflow from YAML sample

## Testing
- `mvnw -DskipTests=false test`

------
https://chatgpt.com/codex/tasks/task_e_684bb4581c6c8324bebf2a6f6ab21f9b